### PR TITLE
Migrate from conda/Python 3.6 to uv/Python 3.11+

### DIFF
--- a/DUDE.py
+++ b/DUDE.py
@@ -111,8 +111,9 @@ if __name__ == "__main__":
 
     feature_dims,nheads,key_dims,value_dims,pro_update_inters,lig_update_iters,pro_lig_update_iters = args.feature_dims,args.nheads,args.key_dims,args.value_dims,\
         args.pro_update_inters,args.lig_update_iters,args.pro_lig_update_iters
-    PLANET = PLANET(feature_dims,nheads,key_dims,value_dims,pro_update_inters,lig_update_iters,pro_lig_update_iters,'cuda').cuda()
-    PLANET.load_state_dict(torch.load(args.PLANET_file))
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    PLANET = PLANET(feature_dims,nheads,key_dims,value_dims,pro_update_inters,lig_update_iters,pro_lig_update_iters,device).to(device)
+    PLANET.load_state_dict(torch.load(args.PLANET_file, map_location=device, weights_only=True))
     out_dir = args.out_dir
     os.makedirs(args.out_dir,exist_ok=True)
 

--- a/PLANET_model.py
+++ b/PLANET_model.py
@@ -88,7 +88,7 @@ class PLANET(nn.Module):
         return lig_interaction_acc,pro_lig_interaction_acc,affinity_mae
 
     def load_parameters(self,parameters=os.path.join(os.path.dirname(os.path.abspath(__file__)),'PLANET.param')):
-        self.load_state_dict(torch.load(parameters,map_location=self.device))
+        self.load_state_dict(torch.load(parameters, map_location=self.device, weights_only=True))
         
     ###used for screening (only one protein, different mols)
     def cal_res_features_helper(self,fresidues,coordinates):

--- a/PLANET_train.py
+++ b/PLANET_train.py
@@ -52,7 +52,8 @@ if __name__ == '__main__':
 
     feature_dims,nheads,key_dims,value_dims,pro_update_inters,lig_update_iters,pro_lig_update_iters = args.feature_dims,args.nheads,args.key_dims,args.value_dims,\
         args.pro_update_inters,args.lig_update_iters,args.pro_lig_update_iters
-    PLANET = PLANET(feature_dims,nheads,key_dims,value_dims,pro_update_inters,lig_update_iters,pro_lig_update_iters,'cuda').cuda()
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    PLANET = PLANET(feature_dims,nheads,key_dims,value_dims,pro_update_inters,lig_update_iters,pro_lig_update_iters,device).to(device)
 
     for param in PLANET.parameters():
         if param.dim() == 1:

--- a/README.md
+++ b/README.md
@@ -7,18 +7,21 @@ Here, we have developed a graph neural network model called PLANET (Protein-Liga
 As tested on the CASF-2016 benchmark, PLANET exhibited a comparable level of scoring power as some other machine learning models that rely on 3D protein-ligand complex structures as inputs. Besides, it exhibited notably better performance in virtual screening trials on the DUD-E and LIT-PCBA benchmarks. Compared to the popular conventional docking program GLIDE, PLANET took less than one percent of computation time to finish the same virtual screening job without a significant loss in accuracy because it did not need to perform exhaustive conformational sampling. In summary, PLANET achieved a decent performance in virtual screening as well as predicting protein-ligand binding affinity. This feature makes PLANET an attractive tool for drug discovery in the real world.
 
 ### Usage
-1. Setup dependencies
+1. Setup dependencies (requires [uv](https://docs.astral.sh/uv/))
 ```bash
-conda env create -f planet.yaml
-conda activate planet
+uv sync
 ```
+This installs PyTorch with CUDA 12.1 support by default. For CPU-only or a different CUDA version edit the index URL in `pyproject.toml` before running `uv sync`:
+- CPU: `https://download.pytorch.org/whl/cpu`
+- CUDA 12.4: `https://download.pytorch.org/whl/cu124`
+
 2. Using PLANET <br>
 We have created a demo folder which includes a protein file (adrb2.pdb), a crystal ligand file (adrb2_ligand.sdf) as well as molecules (mols.sdf) to be estimated. These files are  originally derived from DUD-E dataset and prepared as below: <br>
 (1) The protein structure file (.pdb) are prepared using *prepwizard* in Maestro, including fixing broken residues and assign protonated states. Other structure preparation tools can also be applied. _NOTE:_ The most important is that $\alpha$-carbon of each reasidues must be correctly fixed in the .pdb file.
 (2) The molecule files (mols.sdf) are prepared using *epik* in Maestro, including adding hydrogen atoms and ionized states. the adrb2_ligand.sdf file is only used for determining binding pocket (only need to be in .sdf format).
 ```bash
 cd demo
-python3.6 ../PLANET_run.py -p adrb2.pdb -l adrb2_ligand.sdf -m mols.sdf
+uv run ../PLANET_run.py -p adrb2.pdb -l adrb2_ligand.sdf -m mols.sdf
 ```
 3. Parameters
    - _-p or --protein_, protein structure file;
@@ -29,13 +32,25 @@ python3.6 ../PLANET_run.py -p adrb2.pdb -l adrb2_ligand.sdf -m mols.sdf
 4. Output files <br>
 We provide two output formats including .csv and .sdf
 
-### Training PLANET
-We provided the training scripts called "PLANET_train.py" and "PLANET_datautils.py". But the training data (i.e. PDBbind general set v.2020) are not included in this repository, which can be accessed through: http://pdbbind.org.cn/. <br>
-As mentioned in our paper (in preparation), all structures in general set are prepared and a large number of decoy molecules are used for augmentation. This part of data are not provided to public till now. <br>
-If anyone want to re-train the PLANET (maybe after the training data is released, at that time another folder called 'data' will be released, in which include the summary of training set, validation set and core set in .csv format), here is the protocol: <br>
-suppose the absolute path to PDBbind general set is $DATASET, and all the scripts related to PLANET are in $PLANET. 
+### Training PLANET on PDBbind
+Training data (PDBbind general set v.2020) can be accessed at http://pdbbind.org.cn/. <br>
+Suppose `$DATASET` is the absolute path to your PDBbind dataset directory, `$PK_JSON` is the path to your `PDBbind2020.json` file with pK values, and `$PLANET` is the repo root.
+
+**Step 1 – preprocess structures (runs in parallel with `$NJOBS` workers):**
 ```bash
-python3.6 $PLANET/process_PDBbind.py -d $DATASET -n $njobs
-python3.6 $PLANET/PLANET_datautils.py -p $DATASET -d $PLANET/data/
-python3.6 $PLANET/PLANET_train.py -t $PLANET/data/train.pkl  -v $PLANET/data/valid.pkl -te $PLANET/data/core.pkl -d .
+uv run $PLANET/process_PDBBind.py -d $DATASET -n $NJOBS -k $PK_JSON
+```
+
+**Step 2 – build train/valid/core pickle files:**
+```bash
+uv run $PLANET/PLANET_datautils.py -p $DATASET -d $PLANET/data/
+```
+
+**Step 3 – train:**
+```bash
+uv run $PLANET/PLANET_train.py \
+    -t $PLANET/data/train.pkl \
+    -v $PLANET/data/valid.pkl \
+    -te $PLANET/data/core.pkl \
+    -d .
 ```

--- a/chemutils.py
+++ b/chemutils.py
@@ -1,5 +1,4 @@
 from operator import le
-from numpy.core.fromnumeric import shape
 import pandas as pd
 import rdkit,os
 import rdkit.Chem as Chem

--- a/layers.py
+++ b/layers.py
@@ -1,5 +1,3 @@
-from asyncio import coroutines
-from venv import create
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/nnutils.py
+++ b/nnutils.py
@@ -4,16 +4,18 @@ import torch.nn.functional as F
 from torch.autograd import Variable
 
 def create_var(tensor, requires_grad=None):
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
     if requires_grad is None:
-        return Variable(tensor).cuda()
+        return Variable(tensor).to(device)
     else:
-        return Variable(tensor, requires_grad=requires_grad).cuda()
+        return Variable(tensor, requires_grad=requires_grad).to(device)
 
 def create_var_gpu(tensor, requires_grad=None):
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
     if requires_grad is None:
-        return Variable(tensor).cuda()
+        return Variable(tensor).to(device)
     else:
-        return Variable(tensor, requires_grad=requires_grad).cuda()
+        return Variable(tensor, requires_grad=requires_grad).to(device)
 
 def index_select_ND(source, dim, index):
     index_size = index.size()

--- a/process_PDBBind.py
+++ b/process_PDBBind.py
@@ -4,14 +4,13 @@ from rdkit.RDLogger import ERROR
 from chemutils import ComplexPocket
 from multiprocessing import Pool
 
-def process_PDBBind(record_dir):
+def process_PDBBind(args):
+    record_dir, pK_data_path = args
     pdb_name = record_dir.split('/')[-1]
-    #print('Processing {}'.format(pdb_name))
     ligand_sdf = os.path.join(record_dir,'{}_ligand.sdf'.format(pdb_name))
     protein_pdb = os.path.join(record_dir,'{}_protein.pdb'.format(pdb_name))
     decoy_sdf = os.path.join(record_dir,'{}_decoy.sdf'.format(pdb_name))
-    pK_data_path = '/disk1/aquila/SBDD_model_dock/data/PDBbind2020.json'
-    with open(pK_data_path,'rb') as f:
+    with open(pK_data_path,'r') as f:
         pK_data = json.load(f)
     try:
         pK=pK_data[pdb_name]
@@ -29,16 +28,16 @@ def process_PDBBind(record_dir):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d','--dir',required=True)
-    parser.add_argument('-n','--njobs',required=True,type=int)
+    parser.add_argument('-d','--dir',required=True,help='Path to PDBbind dataset directory')
+    parser.add_argument('-n','--njobs',required=True,type=int,help='Number of parallel jobs')
+    parser.add_argument('-k','--pk_data',required=True,help='Path to PDBbind2020.json with pK values')
     args = parser.parse_args()
     print(args)
-    
 
     base_dir = args.dir
     njobs = args.njobs
 
     pool = Pool(njobs)
 
-    all_records = [os.path.join(base_dir,subdir) for subdir in os.listdir(base_dir)]
-    pool.map(process_PDBBind,all_records)   
+    all_records = [(os.path.join(base_dir,subdir), args.pk_data) for subdir in os.listdir(base_dir)]
+    pool.map(process_PDBBind,all_records)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "planet"
+version = "0.1.0"
+description = "Protein-Ligand Affinity prediction NETwork"
+requires-python = ">=3.11"
+dependencies = [
+    "torch>=2.2",
+    "numpy>=1.24",
+    "scipy>=1.10",
+    "pandas>=2.0",
+    "scikit-learn>=1.3",
+    "matplotlib>=3.7",
+    "rdkit>=2022.9.1",
+    "tqdm>=4.64",
+]
+
+# By default PyTorch is installed from the PyTorch CUDA 12.1 index.
+# For CPU-only: run `uv sync` after changing the index URL to
+#   https://download.pytorch.org/whl/cpu
+# For a different CUDA version change the cu121 suffix accordingly.
+[tool.uv.sources]
+torch = { index = "pytorch-cu121" }
+
+[[tool.uv.index]]
+name = "pytorch-cu121"
+url = "https://download.pytorch.org/whl/cu121"
+explicit = true


### PR DESCRIPTION
- Add pyproject.toml with uv configuration (PyTorch CUDA 12.1 index)
- Fix torch.load() calls: add weights_only=True for modern PyTorch
- Fix hardcoded 'cuda' device: auto-detect cuda/cpu in train and DUDE scripts
- Fix create_var() in nnutils.py: use .to(device) instead of .cuda()
- Remove deprecated numpy.core.fromnumeric import in chemutils.py
- Remove unused asyncio/venv imports in layers.py
- Fix hardcoded pK_data_path in process_PDBBind.py: new -k/--pk_data arg
- Update README with uv-based setup and PDBbind training workflow